### PR TITLE
`cycle` and `fuse` example with rust iterators

### DIFF
--- a/Rust/cycle_and_fuse/Cargo.lock
+++ b/Rust/cycle_and_fuse/Cargo.lock
@@ -1,0 +1,4 @@
+[[package]]
+name = "cycle_and_fuse"
+version = "0.1.0"
+

--- a/Rust/cycle_and_fuse/Cargo.toml
+++ b/Rust/cycle_and_fuse/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "cycle_and_fuse"
+version = "0.1.0"
+authors = ["Ryan James Spencer <spencer.ryanjames@gmail.com>"]
+
+[dependencies]

--- a/Rust/cycle_and_fuse/src/main.rs
+++ b/Rust/cycle_and_fuse/src/main.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let xs: Vec<String> = vec!["a".to_string(),"b".to_string()];
+    // N.B. fuse() doesn't 'cap off' cycle.
+    for x in xs.iter().cycle().fuse() {
+        println!("{:?}", x);
+    }
+}


### PR DESCRIPTION
This shows that `fuse()` will only work if the iterator actually exhausts, which means it has no effect on iterator adapters like `repeat` or `cycle`.